### PR TITLE
Feature expandseeds

### DIFF
--- a/code/helper_functions.py
+++ b/code/helper_functions.py
@@ -40,7 +40,7 @@ def _parse_args():
     parser.add('-c', dest="config", required=True, help='config file path')
     parser.add('-i', action="store_true", dest="individual_mode", help="Turns the individual mode on where the fuzzer is run only for specified seeds.")
     parser.add('-n', action="store_true", dest="no_sending", help="Turns the no-sending mode on where the fuzzer only generates the inputs without sending them to the targets.")
-    parser.add('-s', dest="seed", type=int, help="Only needed for individual mode. Seed parameter for random number generator.")
+    parser.add('-s', dest="seed", help="Only needed for individual mode. Seed parameter for random number generator.")
     parser.add('-v', action="store_true", dest="verbose", help="Only needed for individual mode. Adds verbosity.")
     parser.add('-o', dest="outfilename", help = "Only needed for individual mode. File to write output.")
     parser.add('-f', dest="seedfile", help = "Only needed for individual mode. Input file containing seeds.")


### PR DESCRIPTION
The -s argument now accepts multiple seed values, separated by commas and/or hyphens (no whitespaces).  Non-numeric values will be ignored.  Example: -s 1,3,5-10