### PR TITLE
Add https and secure socket support

### DIFF
--- a/code/helper_functions.py
+++ b/code/helper_functions.py
@@ -11,7 +11,10 @@ def _parse_url(url):
     uri = '/'.join(url.split('/')[3:])
 
     if ':' not in authority:
-        port = 80
+        if 'https://' in url:
+            port = 443
+        else:
+            port = 80
         host = authority
     else:
         host, port = authority.split(':')

--- a/code/main.py
+++ b/code/main.py
@@ -5,6 +5,7 @@ import socket
 import threading
 from multiprocessing import Process, Queue
 import time
+import ssl
 
 from input_tree_node import Node
 from input_tree import InputTree
@@ -74,6 +75,42 @@ class Fuzzer:
             _print_exception([request])
             raise exception
 
+    def send_fuzzy_data_secure(self, inputdata, list_responses):
+        try:
+            request = inputdata.tree_to_request()
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+            _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _s_socket = context.wrap_socket(_socket, server_hostname=inputdata.host)
+
+            _s_socket.connect((inputdata.host, int(inputdata.port)))
+            _s_socket.sendall(request)
+            _s_socket.settimeout(4)
+
+            response = b''
+            while True:
+                data = _s_socket.recv(2048)
+                if not data:
+                    break
+                else:
+                    response += data
+
+            _s_socket.shutdown(socket.SHUT_RDWR)
+            _s_socket.close()
+            _socket.close()
+
+            with self.lock:
+                list_responses.append(response)
+        except socket.timeout:
+            with self.lock:
+                list_responses.append(b"takes too long")
+
+        except Exception as exception:
+            _print_exception([request])
+            raise exception
+
     def get_responses(self, seed, request):
         threads = []
         list_responses = []
@@ -83,7 +120,10 @@ class Fuzzer:
             request.host_header = self.target_hosts[target_url]
 
             request_copy = copy.deepcopy(request)
-            thread = threading.Thread(target=self.send_fuzzy_data, args=(request_copy, list_responses))
+            if request.url.startswith("https"):
+                thread = threading.Thread(target=self.send_fuzzy_data_secure, args=(request_copy, list_responses))
+            else:
+                thread = threading.Thread(target=self.send_fuzzy_data, args=(request_copy, list_responses))
             threads.append(thread)
             thread.start()
 


### PR DESCRIPTION
If a target_url contains `https://`, t-reqs uses ssl socket to be able to connect to the target server.